### PR TITLE
Bumps replicas up to three

### DIFF
--- a/k8s/petclinic-app.yaml
+++ b/k8s/petclinic-app.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app: spring-petclinic
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: spring-petclinic


### PR DESCRIPTION
TL;DR
-----

Runs 3 replicas instead of the original 2 for policy compliance

Details
-------

Updates the deployment manifest to deploy with 3 replicas to come
into compliance with a resiliency policy requiring a minimum of
three replicas to allow deployment.